### PR TITLE
Implement global throttling

### DIFF
--- a/lib/grape/attack/configuration.rb
+++ b/lib/grape/attack/configuration.rb
@@ -2,11 +2,14 @@ module Grape
   module Attack
     class Configuration
 
-      attr_accessor :adapter, :disable
+      attr_accessor :adapter, :disable, :global_throttling, :global_throttling_max, :global_throttling_per
 
       def initialize
         @adapter = ::Grape::Attack::Adapters::Redis.new
         @disable = Proc.new { false }
+        @global_throttling = false
+        @global_throttling_max = 500
+        @global_throttling_per = 1.day
       end
 
     end

--- a/lib/grape/attack/counter.rb
+++ b/lib/grape/attack/counter.rb
@@ -28,7 +28,11 @@ module Grape
       private
 
       def key
-        "#{request.method}:#{request.path}:#{request.client_identifier}"
+        if request.throttle_options.global_throttling
+          "#{request.client_identifier}"
+        else
+          "#{request.method}:#{request.path}:#{request.client_identifier}"
+        end
       end
 
       def ttl_in_seconds

--- a/lib/grape/attack/options.rb
+++ b/lib/grape/attack/options.rb
@@ -5,15 +5,26 @@ module Grape
     class Options
       include ActiveModel::Model
 
-      attr_accessor :max, :per, :identifier, :remaining
+      attr_accessor :max, :per, :identifier, :global_throttling, :remaining
 
-      validates :max, presence: true
-      validates :per, presence: true
+      validates :max, presence: true, unless: :global_throttling
+      validates :per, presence: true, unless: :global_throttling
 
       def identifier
         @identifier || Proc.new {}
       end
 
+      def max
+        global_throttling ? ::Grape::Attack.config.global_throttling_max : @max
+      end
+
+      def per
+        global_throttling ? ::Grape::Attack.config.global_throttling_per : @per
+      end
+
+      def global_throttling
+        @global_throttling.nil? ? ::Grape::Attack.config.global_throttling : @global_throttling
+      end
     end
   end
 end

--- a/lib/grape/attack/throttle.rb
+++ b/lib/grape/attack/throttle.rb
@@ -17,9 +17,9 @@ module Grape
         return if ::Grape::Attack.config.disable.call
         return unless request.throttle?
 
-        @app_response['X-RateLimit-Limit']     = request.context.route_setting(:throttle)[:max].to_s
-        @app_response['X-RateLimit-Remaining'] = request.context.route_setting(:throttle)[:remaining].to_s
-        @app_response['X-RateLimit-Reset']     = request.context.route_setting(:throttle)[:per].from_now.to_i.to_s
+        @app_response['X-RateLimit-Limit']     = request.throttle_options.max.to_s
+        @app_response['X-RateLimit-Remaining'] = request.throttle_options.remaining.to_s
+        @app_response['X-RateLimit-Reset']     = request.throttle_options.per.from_now.to_i.to_s
         @app_response
       end
 


### PR DESCRIPTION
Allow users to specify `global_throttling`, meaning all requests from an identifier to an endpoint with `global_throttling` enabled contribute toward the `global_throttling_max`.

Useful for app-wide throttling
