### PR TITLE
Rate limiting reset fix

### DIFF
--- a/lib/grape/attack/adapters/memory.rb
+++ b/lib/grape/attack/adapters/memory.rb
@@ -13,6 +13,10 @@ module Grape
           data[key]
         end
 
+        def set(key, value)
+          data[key] = value
+        end
+
         def incr(key)
           data[key] ||= 0
           data[key] += 1

--- a/lib/grape/attack/adapters/redis.rb
+++ b/lib/grape/attack/adapters/redis.rb
@@ -17,6 +17,12 @@ module Grape
           end
         end
 
+        def set(key, value)
+          with_custom_exception do
+            broker.set(key, value)
+          end
+        end
+
         def incr(key)
           with_custom_exception do
             broker.incr(key)

--- a/lib/grape/attack/counter.rb
+++ b/lib/grape/attack/counter.rb
@@ -10,7 +10,14 @@ module Grape
       end
 
       def value
-        fetch[0]
+        val, exp = fetch
+
+        if exp > Time.now.to_i
+          val
+        else
+          store(0, ttl_in_seconds.seconds.from_now.to_i)
+          fetch[0]
+        end
       end
 
       def reset_at

--- a/lib/grape/attack/counter.rb
+++ b/lib/grape/attack/counter.rb
@@ -13,6 +13,10 @@ module Grape
         fetch[0]
       end
 
+      def reset_at
+        fetch[1]
+      end
+
       def update
         adapter.atomically do
           value, exp = fetch

--- a/lib/grape/attack/limiter.rb
+++ b/lib/grape/attack/limiter.rb
@@ -44,7 +44,8 @@ module Grape
       end
 
       def set_rate_limit_headers
-        request.context.route_setting(:throttle)[:remaining] = [0, max_requests_allowed - (counter.value + 1)].max
+        request.context.route_setting(:throttle)[:remaining] = [0, max_requests_allowed - counter.value].max
+        request.context.route_setting(:throttle)[:reset_at] = [Time.now.to_i, counter.reset_at].max
       end
 
       def max_requests_allowed

--- a/lib/grape/attack/options.rb
+++ b/lib/grape/attack/options.rb
@@ -6,7 +6,7 @@ module Grape
       include ActiveModel::Model
       include ActiveModel::Validations
 
-      attr_accessor :max, :per, :identifier, :remaining
+      attr_accessor :max, :per, :identifier, :remaining, :reset_at
 
       class ProcOrNumberValidator < ActiveModel::EachValidator
         def validate_each(record, attribute, value)

--- a/lib/grape/attack/throttle.rb
+++ b/lib/grape/attack/throttle.rb
@@ -15,7 +15,7 @@ module Grape
         return unless request.throttle?
 
         header('X-RateLimit-Limit', request.throttle_options.max.to_s)
-        header('X-RateLimit-Reset', request.throttle_options.per.to_s)
+        header('X-RateLimit-Reset', request.throttle_options.reset_at.to_s)
         header('X-RateLimit-Remaining', request.throttle_options.remaining.to_s)
 
         @app_response


### PR DESCRIPTION
Fixes #11 by storing both the request count and the reset time in the value of the cache, allowing keys to have correct expiry, and correctly showing reset information in header.
