### PR TITLE
Expand functionality of RateLimitExceededError

### DIFF
--- a/lib/grape/attack/exceptions.rb
+++ b/lib/grape/attack/exceptions.rb
@@ -2,6 +2,18 @@ module Grape
   module Attack
     StoreError = Class.new(StandardError)
     Exceptions = Class.new(StandardError)
-    RateLimitExceededError = Class.new(Exceptions)
+
+    class RateLimitExceededError < Exceptions
+      attr_reader :client_identifier
+
+      def initialize(msg = nil, client_identifier: nil)
+        @client_identifier = client_identifier
+
+        return super(msg) if msg
+
+        msg = 'API rate limit exceeded'
+        super(client_identifier ? "#{msg} for #{client_identifier}" : msg)
+      end
+    end
   end
 end

--- a/lib/grape/attack/limiter.rb
+++ b/lib/grape/attack/limiter.rb
@@ -21,7 +21,7 @@ module Grape
           update_counter
           set_rate_limit_headers
         else
-          fail ::Grape::Attack::RateLimitExceededError.new("API rate limit exceeded for #{request.client_identifier}.")
+          fail ::Grape::Attack::RateLimitExceededError.new(client_identifier: request.client_identifier)
         end
       end
 


### PR DESCRIPTION
Hi @gottfrois,

I am working on API for my project and I have to specify each error message for different languages. 
It would be very useful to have raw information inside `RateLimitExceededError`.
I also think that the error could have a default message inside too.

What do you think about it? Do you have any suggestions for the implementation?