### PR TITLE
Support Grape 1.x

### DIFF
--- a/grape-attack.gemspec
+++ b/grape-attack.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "grape", "~> 0.16"
+  spec.add_dependency "grape", ">= 0.16", "< 2.0"
   spec.add_dependency "redis-namespace", "~> 1.5"
   spec.add_dependency "activemodel", ">= 4.0"
   spec.add_dependency "activesupport", ">= 4.0"


### PR DESCRIPTION
I did a basic sanity check and things appear to work on Grape 1.1 unmodified. There's a [security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2018-3769) that makes upgrading Grape prudent.